### PR TITLE
Disable multicast in nac_bypass_setup.sh

### DIFF
--- a/nac_bypass_setup.sh
+++ b/nac_bypass_setup.sh
@@ -153,6 +153,10 @@ InitialSetup() {
     sysctl -p
     echo "" > /etc/resolv.conf
 
+    # Turn off multicast to prevent initial IGMP messages
+    ip link set $SWINT multicast off
+    ip link set $COMPINT multicast off
+    
     # Stop NTP services
     declare -a NTP_SERVICES=("ntp.service" "ntpsec.service" "chronyd.service" "systemd-timesyncd.service")
     for NTP_SERVICE in "${NTP_SERVICES[@]}"


### PR DESCRIPTION
In most tested cases the script ran without any issues. In one use case, the switch took the interface down. We noticed that when plugging in the network cable, an IGMP message to sign up for multicast is sent. This is done with the real MAC of the interface.

The proposed change does disable multicast and hence no IGMP packet is sent.