### PR TITLE
Allow to pass manually supplicant adresses as arguments for better stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ nac_bypass_setup.sh v0.6.4 usage:
     -a          autonomous mode
     -c          start connection setup only
     -g <MAC>    set gateway MAC address (GWMAC) manually
+    -t <MAC>    set target (printer or computer) MAC address (COMMAC) manually
+    -T <IP>     set target (printer or computer) IP  address (COMIP) manually
     -h          display this help
     -i          start initial setup only
     -r          reset all settings

--- a/awareness.sh
+++ b/awareness.sh
@@ -36,14 +36,26 @@ Version() {
 
 ## Check if we got all needed parameters
 CheckParams() {
-  while getopts ":1:2:h" opts
+  while getopts ":1:2:g:t:T:hRS" opts
     do
       case "$opts" in
         "1")
           SWINT=$OPTARG
+          # --- use both this argument for current and subsequent script ---
+          passthrough_args+=("-${opts}" "${OPTARG}")
           ;;
         "2")
           COMPINT=$OPTARG
+          # --- use both this argument for current and subsequent script ---
+          passthrough_args+=("-${opts}" "${OPTARG}")
+          ;;
+        # --- Options to be passed through without parameter ---
+        R|S)
+          passthrough_args+=("-${opts}")
+          ;;
+        # --- Options to be passed through with a parameter ---
+        g|t|T)
+          passthrough_args+=("-${opts}" "${OPTARG}")
           ;;
         "h")
           Usage
@@ -59,7 +71,7 @@ CheckParams() {
 CheckParams $@
 
 ## Run Initial Configuration
-bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -i -1 $SWINT -2 $COMPINT
+bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -i "${passthrough_args[@]}"
 
 ## Loop
 while true
@@ -79,12 +91,12 @@ do
 
         if [ "$STATE_COUNTER" -eq "$THRESHOLD_UP" ] && [ "$NETWORK_STATE_INTERFACE" -eq 1 ]; then
             echo "[!!] Set new config"
-            bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -c -1 $SWINT -2 $COMPINT
+            bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -c "${passthrough_args[@]}"
  
         elif [ "$STATE_COUNTER" -eq "$THRESHOLD_DOWN" ] && [ "$NETWORK_STATE_INTERFACE" -eq 0 ]; then
             echo "[!!] Reset config"
             bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -r
-            bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -i -1 $SWINT -2 $COMPINT
+            bash "${SCRIPT_DIR}/nac_bypass_setup.sh" -a -i "${passthrough_args[@]}"
         fi
 
         echo "[*] Waiting"

--- a/nac_bypass.service
+++ b/nac_bypass.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NAC Bypass Automatic
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/nac_bypass_awareness.sh -1 enp2s0 -2 enp1s0
+# ExecStart=/usr/local/bin/nac_bypass_awareness.sh -1 enp2s0 -2 enp1s0 -g 01:01:01:01:01:01 -t 02:02:02:02:02:02 -T 10.1.2.3 -S
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Allow supplicant IP & MAC to be manually defined using arguments to skip automatic detection, which might be unreliable (notably if supplicant is a server, e.g., printer)
- Allow args to be passed to `awareness.sh`, and passed though to `nac_bypass.sh`
- Supply a basic service file example 