### PR TITLE
Fix syntax errors in options parsing

### DIFF
--- a/nac_bypass_setup.sh
+++ b/nac_bypass_setup.sh
@@ -118,8 +118,10 @@ CheckParams() {
           ;;
         "T")
           COMIP=$OPTARG
+          ;;
         "f")
           RESTRICT_TO_DEST_RANGE=$OPTARG
+          ;;
         "s")
           TO_COMP_SOURCE_IP=$OPTARG
           ;;


### PR DESCRIPTION
Thanks for the useful script. I think there are some syntax errors that this PR fixes, though my bash scripting is quite bad.

In addition, on debian 13 I ran into the issue that `/etc/sysctl.conf` no longer exists.
Fixed it manually by running `echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/disableipv6.conf`, maybe a future fix would be to check for this in the script.
There may be other issues with debian 13 that I haven't run into yet.