### PR TITLE
Update iptables forward policy for bridge setup

### DIFF
--- a/nac_bypass_setup.sh
+++ b/nac_bypass_setup.sh
@@ -231,6 +231,9 @@ InitialSetup() {
     ## Bringing up the Bridge
     ifconfig $BRINT 0.0.0.0 up promisc
 
+    ## Set default iptables forward policy to ACCEPT to avoid bridge from being non functional 
+    $CMD_IPTABLES -P FORWARD ACCEPT
+
     if [ "$OPTION_AUTONOMOUS" -eq 0 ]; then
         echo
         echo -e "$SUCC [ + ] Bridge up, should be dark.$TXTRST"


### PR DESCRIPTION
Set default iptables forward policy to ACCEPT to ensure bridge functionality (~and avoid wasting your time debugging~).

For example, default kali will block traffic without this rule being added